### PR TITLE
Add an env variable to allow disabling the device reset step.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "usb-power-profiling",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "usb-power-profiling",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "license": "MPL-2.0",
       "dependencies": {
         "crc-full": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "usb-power-profiling",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "Make USB power meters usable with the Firefox Profiler",
   "homepage": "https://github.com/fqueze/usb-power-profiling/",
   "repository": "github:fqueze/usb-power-profiling",

--- a/usb-power-profiling.js
+++ b/usb-power-profiling.js
@@ -43,14 +43,21 @@ function int32Bytes(number) {
 }
 
 function resetDevice(device) {
-  return new Promise((resolve, reject) => device.reset(error => {
-    if (error) {
-      console.log("failed to reset device", error);
-      reject(error);
-    } else {
-      resolve();
+  return new Promise((resolve, reject) => {
+      if (process.env.DISABLE_USB_POWER_METER_RESET) {
+        resolve();
+      } else {
+        device.reset(error => {
+          if (error) {
+            console.log("failed to reset device", error);
+            reject(error);
+          } else {
+            resolve();
+          }
+        });
+      }
     }
-  }));
+  );
 }
 
 function sendBuffer(endPointOut, buffer) {


### PR DESCRIPTION
In some configurations, the device reset can trigger the loss of a connection to the power meter that is measuring a device. This patch adds an environment variable called `DISABLE_USB_POWER_METER_RESET` to allow us to disable the device resets.